### PR TITLE
Refact GPU imfilter padding

### DIFF
--- a/src/imfilter.jl
+++ b/src/imfilter.jl
@@ -13,7 +13,7 @@ function imfilter_gpu(img, krn)
 
   # pad kernel to common size with image
   padsize = size(img) .- size(krn)
-  padkrn = padarray(krn, Fill(zero(T), ntuple(i->0, N), padsize))
+  padkrn  = padarray(krn, Fill(zero(T), ntuple(i->0, N), padsize))
 
   # perform ifft(fft(img) .* conj.(fft(krn)))
   fftimg = img |> CuArray |> CUFFT.fft

--- a/src/imfilter.jl
+++ b/src/imfilter.jl
@@ -18,12 +18,11 @@ function imfilter_gpu(img, krn)
   # perform ifft(fft(img) .* conj.(fft(krn)))
   fftimg = img |> CuArray |> CUFFT.fft
   fftkrn = padkrn |> CuArray |> CUFFT.fft
-  result = (fftimg .* conj.(fftkrn)) |> CUFFT.ifft
+  fftresult = (fftimg .* conj.(fftkrn)) |> CUFFT.ifft
 
   # recover result
   finalsize = size(img) .- (size(krn) .- 1)
-  result = real.(result[CartesianIndices(finalsize)]) |> Array
-  result
+  real.(fftresult[CartesianIndices(finalsize)]) |> Array
 end
 
 const imfilter_kernel = CUDA.functional() ? imfilter_gpu : imfilter_cpu

--- a/src/imfilter.jl
+++ b/src/imfilter.jl
@@ -18,7 +18,7 @@ function imfilter_gpu(img, krn)
   # perform ifft(fft(img) .* conj.(fft(krn)))
   fftimg = img |> CuArray |> CUFFT.fft
   fftkrn = padkrn |> CuArray |> CUFFT.fft
-  fftresult = (fftimg .* conj.(fftkrn)) |> CUFFT.ifft
+  result = (fftimg .* conj.(fftkrn)) |> CUFFT.ifft
 
   # recover result
   finalsize = size(img) .- (size(krn) .- 1)

--- a/src/imfilter.jl
+++ b/src/imfilter.jl
@@ -11,19 +11,17 @@ function imfilter_gpu(img, krn)
   N = ndims(img)
   T = eltype(img)
 
-  # pad images to common size
-  padimg  = padarray(img, Fill(zero(T), ntuple(i->0, N), size(krn) .- 1))
-  padkrn  = padarray(krn, Fill(zero(T), ntuple(i->0, N), size(img) .- 1))
+  # pad kernel to common size
+  padsize = size(img) .- size(krn)
+  padkrn = padarray(krn, Fill(zero(T), ntuple(i->0, N), padsize))
 
   # perform ifft(fft(img) .* conj.(fft(krn)))
   fftimg = padimg |> CuArray |> CUFFT.fft
   fftkrn = padkrn |> CuArray |> CUFFT.fft
   result = (fftimg .* conj.(fftkrn)) |> CUFFT.ifft
 
-  # unpad result
-  start  = CartesianIndex(ntuple(i->1, N))
-  finish = CartesianIndex(size(img) .- (size(krn) .- 1))
-  real.(result[start:finish]) |> Array
+  # recover result
+  result |> Array
 end
 
 const imfilter_kernel = CUDA.functional() ? imfilter_gpu : imfilter_cpu

--- a/src/imfilter.jl
+++ b/src/imfilter.jl
@@ -11,7 +11,7 @@ function imfilter_gpu(img, krn)
   N = ndims(img)
   T = eltype(img)
 
-  # pad kernel to common size with img
+  # pad kernel to common size with image
   padsize = size(img) .- size(krn)
   padkrn = padarray(krn, Fill(zero(T), ntuple(i->0, N), padsize))
 

--- a/src/imfilter.jl
+++ b/src/imfilter.jl
@@ -22,7 +22,7 @@ function imfilter_gpu(img, krn)
 
   # recover result
   finalsize = size(img) .- (size(krn) .- 1)
-  real.(fftresult[CartesianIndices(finalsize)]) |> Array
+  real.(result[CartesianIndices(finalsize)]) |> Array
 end
 
 const imfilter_kernel = CUDA.functional() ? imfilter_gpu : imfilter_cpu

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 GR = "28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71"
 GeoStatsBase = "323cb8eb-fbf6-51c0-afd0-f8fba70507b2"
 GeoStatsImages = "7cd16168-b42c-5e7d-a585-4f59d326662d"
@@ -12,5 +13,6 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+CUDA = "3.11"
 GR = "=0.59.0"
 Plots = "=1.22.4"

--- a/test/lowapi.jl
+++ b/test/lowapi.jl
@@ -156,8 +156,8 @@ if CUDA.functional()
     @test isapprox(result_cpu[:], result_gpu[:], atol=tolerance)
     
     # 3D imfilter
-    img = rand(60, 40, 50)
-    krn = rand(9, 6, 15)
+    img = rand(50, 100, 150)
+    krn = rand(10, 20, 30)
     
     result_cpu = ImageQuilting.imfilter_cpu(img, krn)
     result_gpu = ImageQuilting.imfilter_gpu(img, krn)

--- a/test/lowapi.jl
+++ b/test/lowapi.jl
@@ -141,3 +141,25 @@ if visualtests
     @test_reference "data/Voxel$(TIname).png" voxelreuseplot(TI, rng=rng)
   end
 end
+
+if CUDA.functional()
+  @testset "GPU imfilter is equivalent to CPU imfilter" begin
+    tolerance = 0.000001
+
+    # 2D imfilter
+    img = rand(Uniform(-100, 100), (120, 60))
+    krn = rand(Uniform(-100, 100), (30, 10))
+
+    result_cpu = ImageQuilting.imfilter_cpu(img, krn)
+    result_gpu = ImageQuilting.imfilter_gpu(img, krn)
+    @test isapprox(result_cpu, result_gpu, atol=tolerance)
+    
+    # 3D imfilter
+    img = rand(Uniform(-100, 100), (60, 40, 50))
+    krn = rand(Uniform(-100, 100), (9, 6, 15))
+    
+    result_cpu = ImageQuilting.imfilter_cpu(img, krn)
+    result_gpu = ImageQuilting.imfilter_gpu(img, krn)
+    @test isapprox(result_cpu, result_gpu, atol=tolerance)
+  end
+end

--- a/test/lowapi.jl
+++ b/test/lowapi.jl
@@ -144,19 +144,19 @@ end
 
 if CUDA.functional()
   @testset "GPU imfilter is equivalent to CPU imfilter" begin
-    tolerance = 0.000001
+    tolerance = 1e-5
 
     # 2D imfilter
-    img = rand(Uniform(-100, 100), (120, 60))
-    krn = rand(Uniform(-100, 100), (30, 10))
+    img = rand(120, 60)
+    krn = rand(30, 10)
 
     result_cpu = ImageQuilting.imfilter_cpu(img, krn)
     result_gpu = ImageQuilting.imfilter_gpu(img, krn)
     @test isapprox(result_cpu, result_gpu, atol=tolerance)
     
     # 3D imfilter
-    img = rand(Uniform(-100, 100), (60, 40, 50))
-    krn = rand(Uniform(-100, 100), (9, 6, 15))
+    img = rand(60, 40, 50)
+    krn = rand(9, 6, 15)
     
     result_cpu = ImageQuilting.imfilter_cpu(img, krn)
     result_gpu = ImageQuilting.imfilter_gpu(img, krn)

--- a/test/lowapi.jl
+++ b/test/lowapi.jl
@@ -147,7 +147,7 @@ if CUDA.functional()
     tolerance = 1e-5
 
     # 2D imfilter
-    img = rand(120, 60)
+    img = rand(200, 100)
     krn = rand(30, 10)
 
     result_cpu = ImageQuilting.imfilter_cpu(img, krn)

--- a/test/lowapi.jl
+++ b/test/lowapi.jl
@@ -143,7 +143,7 @@ if visualtests
 end
 
 if CUDA.functional()
-  @testset "GPU imfilter is equivalent to CPU imfilter" begin
+  @testset "CPU and GPU imfilters are equivalent" begin
     tolerance = 1e-5
 
     # 2D imfilter
@@ -152,7 +152,8 @@ if CUDA.functional()
 
     result_cpu = ImageQuilting.imfilter_cpu(img, krn)
     result_gpu = ImageQuilting.imfilter_gpu(img, krn)
-    @test isapprox(result_cpu, result_gpu, atol=tolerance)
+    @test size(result_cpu) == size(result_gpu)
+    @test isapprox(result_cpu[:], result_gpu[:], atol=tolerance)
     
     # 3D imfilter
     img = rand(60, 40, 50)
@@ -160,6 +161,7 @@ if CUDA.functional()
     
     result_cpu = ImageQuilting.imfilter_cpu(img, krn)
     result_gpu = ImageQuilting.imfilter_gpu(img, krn)
-    @test isapprox(result_cpu, result_gpu, atol=tolerance)
+    @test size(result_cpu) == size(result_gpu)
+    @test isapprox(result_cpu[:], result_gpu[:], atol=tolerance)
   end
 end

--- a/test/lowapi.jl
+++ b/test/lowapi.jl
@@ -143,7 +143,7 @@ if visualtests
 end
 
 if CUDA.functional()
-  @testset "CPU and GPU imfilters are equivalent" begin
+  @testset "CPU vs GPU" begin
     tolerance = 1e-5
 
     # 2D imfilter

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using GeoStatsBase
 using GeoStatsImages
 using ImageFiltering
 using Statistics
+using CUDA
 using Plots; gr(size=(600,400))
 using ReferenceTests, ImageIO
 using Test, Random


### PR DESCRIPTION
This PR aims to optimize the `imfilter_gpu` function.
The idea is to remove the padding applied to the `img` and pad only the `krn` to have the same size of `img`. 