### PR TITLE
Change CuArrays type from Float64 to Float32

### DIFF
--- a/src/imfilter.jl
+++ b/src/imfilter.jl
@@ -12,12 +12,12 @@ function imfilter_gpu(img, krn)
   T = eltype(img)
 
   # pad kernel to common size with image
-  padkrn = CUDA.zeros(size(img))
-  copyto!(padkrn, CartesianIndices(krn), CuArray(krn), CartesianIndices(krn))
+  padkrn = CUDA.zeros(Float32, size(img))
+  copyto!(padkrn, CartesianIndices(krn), array_gpu(krn), CartesianIndices(krn))
 
   # perform ifft(fft(img) .* conj.(fft(krn)))
   fftimg = img |> CUFFT.fft
-  fftkrn = padkrn |> CuArray |> CUFFT.fft
+  fftkrn = padkrn |> CUFFT.fft
   result = (fftimg .* conj.(fftkrn)) |> CUFFT.ifft
 
   # recover result

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -56,7 +56,7 @@ end
 
 array_cpu(array) = array
 
-array_gpu(array) = CuArray(array)
+array_gpu(array) = CuArray{Float32}(array)
 
 const array_kernel = CUDA.functional() ? array_gpu : array_cpu
 

--- a/test/lowapi.jl
+++ b/test/lowapi.jl
@@ -149,7 +149,7 @@ if CUDA.functional()
     krn = rand(30, 10)
 
     result_cpu = ImageQuilting.imfilter_cpu(img, krn)
-    result_gpu = ImageQuilting.imfilter_gpu(CuArray(img), krn)
+    result_gpu = ImageQuilting.imfilter_gpu(CuArray{Float32}(img), krn)
     @test size(result_cpu) == size(result_gpu)
     @test isapprox(result_cpu[:], result_gpu[:], atol=1e-2)
     
@@ -158,8 +158,8 @@ if CUDA.functional()
     krn = rand(10, 20, 30)
     
     result_cpu = ImageQuilting.imfilter_cpu(img, krn)
-    result_gpu = ImageQuilting.imfilter_gpu(CuArray(img), krn)
+    result_gpu = ImageQuilting.imfilter_gpu(CuArray{Float32}(img), krn)
     @test size(result_cpu) == size(result_gpu)
-    @test isapprox(result_cpu[:], result_gpu[:], atol=1e-1)
+    @test isapprox(result_cpu[:], result_gpu[:], atol=1e-3)
   end
 end


### PR DESCRIPTION
This PR aims obtain a better performance on GPU by using CuArrays with Float32 type.

<details>
<summary> Performance test </summary>

Google Cloud VM:
 * n1-standard-2 (2 vCPUs, 8gb memory)
 * 1 x NVIDIA Tesla T4 ([details](https://cloud.google.com/compute/docs/gpus?hl=pt_br))

code: 
```julia
using ImageQuilting

TI = rand(100, 100, 100)
tilesize = (10, 10, 10)

@time ImageQuilting.iqsim(
  TI,
  tilesize
)

```

Result:
* using Float64: `33.592089 seconds (18.75 M allocations: 40.698 GiB, 3.04% gc time)`
* using Float32: `21.736202 seconds (18.95 M allocations: 28.386 GiB, 4.11% gc time)`
* without GPU: `277.141288 seconds (17.90 M allocations: 290.850 GiB, 2.65% gc time)` 
</details>
